### PR TITLE
Make articles work when opened directly

### DIFF
--- a/src/pages/article/[[...slug]].js
+++ b/src/pages/article/[[...slug]].js
@@ -8,7 +8,7 @@ export default function Article({ issue, article }) {
   const [height, setHeight] = React.useState("0px");
 
   const onLoad = () => {
-    setHeight(ref.current.contentWindow.document.body.scrollHeight + "px");
+    setHeight(ref.current.contentWindow.document.body?.scrollHeight + "px");
   };
 
   useEffect(onLoad, [ref]);


### PR DESCRIPTION
If you browse directly to a USTJ article, without ever having visited the main site, you should get this error:

```
Application error: a client-side exception has occurred (see the browser console for more information).
```

In the console, we see that an attribute, `scrollHeight`, is accessed from null.

```
TypeError: Cannot read properties of null (reading 'scrollHeight')
    at u ([[...slug]]-3ceb6c7e07095388.js:1:4122)
    at uU (framework-2c16ac744b6cdea6.js:9:84106)
    at oV (framework-2c16ac744b6cdea6.js:9:113152)
    at o (framework-2c16ac744b6cdea6.js:9:107705)
    at x (framework-2c16ac744b6cdea6.js:33:1364)
    at MessagePort.T (framework-2c16ac744b6cdea6.js:33:1894)
a9 @ framework-2c16ac744b6cdea6.js:9
main-3f4b50d11d6df7af.js:1 TypeError: Cannot read properties of null (reading 'scrollHeight')
    at u ([[...slug]]-3ceb6c7e07095388.js:1:4122)
    at uU (framework-2c16ac744b6cdea6.js:9:84106)
    at oV (framework-2c16ac744b6cdea6.js:9:113152)
    at o (framework-2c16ac744b6cdea6.js:9:107705)
    at x (framework-2c16ac744b6cdea6.js:33:1364)
    at MessagePort.T (framework-2c16ac744b6cdea6.js:33:1894)
```

Thanks to the simplicity of how this codebase's files are organized, it's easy to find the problematic code inside of src/pages/article/[[...slug]].js

https://github.com/urbit/ustj.urbit.org/blob/9ccd520567e1be1c5ec65c7297501171c98c87ce/src/pages/article/%5B%5B...slug%5D%5D.js#L16-L18

The issue here is that sometimes, for complicated React reasons,`ref.local` and some of its children turn out to be null if you check for them too early. Actually quite a common bug, eg: [React ref.current is null](https://stackoverflow.com/questions/55248483/react-ref-current-is-null)

Btw, this bug isn't reproducible if you try it on localhost via `npm run dev`, prolly how it slipped past the hawk eyes of this repo's maintainers. However, the bug _doesSo_ to check if this fix works, I deployed my fix to vercel (just like the _real_ USTJ!!1!) via the free Hobby Tier (hopefully not like the _real_ USTJ since that would provide an easy denial of service vector for envious Kinoders to exploit). And... after hard refreshing to load the page with no cache (which is how I initially found the bug on the live site)....

![Screenshot 2024-06-11 at 8 51 18 a m](https://github.com/urbit/ustj.urbit.org/assets/104947308/02b667a1-e4c2-4d7d-84d1-bf208643e81a)

It works! You can experience my change for yourself here: https://ustj-urbit-mo2ygwuz8-darighosts-projects.vercel.app/article/v01-i01/the-stakes-of-scrying-dotket-and-the-seer-proposal